### PR TITLE
Remove content moderation settings from publications form display

### DIFF
--- a/config/install/core.entity_form_display.node.publications.default.yml
+++ b/config/install/core.entity_form_display.node.publications.default.yml
@@ -1,4 +1,3 @@
-uuid: 4d2023ba-e236-49f1-8339-dd4956ade728
 langcode: en
 status: true
 dependencies:
@@ -24,7 +23,6 @@ dependencies:
     - field.field.node.publications.field_pub_year_publication
     - node.type.publications
   module:
-    - content_moderation
     - datetime
     - field_group
     - link
@@ -251,12 +249,6 @@ content:
     region: content
     settings:
       placeholder: ''
-    third_party_settings: { }
-  moderation_state:
-    type: moderation_state_default
-    weight: 100
-    region: content
-    settings: { }
     third_party_settings: { }
   path:
     type: path


### PR DESCRIPTION
This commit removes unused `content_moderation` dependencies and associated configuration from the publications form display, simplifying and cleaning up the file.